### PR TITLE
Fix path error of yasm.exe

### DIFF
--- a/yasm.props
+++ b/yasm.props
@@ -6,7 +6,7 @@
     <YASMAfterTargets>CustomBuild</YASMAfterTargets>
   </PropertyGroup>
   <PropertyGroup>
-    <YasmPath Condition= "'$(YASMPATH)' == ''">$(VCInstallDir)</YasmPath>
+    <YasmPath Condition= "'$(YASMPATH)' == ''">$(VCInstallDir)bin\</YasmPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <YASM>


### PR DESCRIPTION
In the `readme`, the suggested `yasm.exe` path is:
` C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin `
However, in `yasm.props` the directory is set as '$(VCInstallDir)'.

PS: `YASMPATH` environment is not set.